### PR TITLE
Modify user model validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,16 @@
 class User < ApplicationRecord
   has_secure_password
 
+  before_save :downcase_email
+
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
-  validates :email, presence: true, uniqueness: { case_sensitive: false }, format: { with: VALID_EMAIL_REGEX }
+  validates :email, presence: true, uniqueness: { case_sensitive: false },
+                    format: { with: VALID_EMAIL_REGEX }, length: { maximum: 255 }
+  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
+
+  private
+
+    def downcase_email
+      email.downcase!
+    end
 end

--- a/db/migrate/20200511235929_change_users_columns_not_null.rb
+++ b/db/migrate/20200511235929_change_users_columns_not_null.rb
@@ -1,0 +1,7 @@
+class ChangeUsersColumnsNotNull < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :users, :email, false
+    change_column_null :users, :password_digest, false
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_21_090718) do
+ActiveRecord::Schema.define(version: 2020_05_11_235929) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "email"
-    t.string "password_digest"
+    t.string "email", null: false
+    t.string "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:email) { |n| "test#{n}@example.com"}
+    password { 'password' }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  it 'has a valid factory' do
+    expect(build(:user)).to be_valid
+  end
+
+  describe 'validation' do
+    it { is_expected.to validate_presence_of :email }
+    it { is_expected.to validate_presence_of :password }
+
+    it 'password should be 6 characters or more' do
+      user = build(:user, password: 'a' * 5)
+      expect(user).to_not be_valid
+
+      user.password = 'a' * 6
+      expect(user).to be_valid
+    end
+
+    it 'email should be less than 256 characters' do
+      user = build(:user, email: 'a' * 244 + '@example.com')
+      expect(user).to_not be_valid
+
+      user = build(:user, email: 'a' * 243 + '@example.com')
+      expect(user).to be_valid
+    end
+
+    it 'email validation should accept valid addresses' do
+      user = build(:user)
+      valid_addresses = %w(user@example.com USER@foo.COM A_US-ER@foo.bar.org
+                         first.last@foo.jp alice+bob@baz.cn)
+      valid_addresses.each do |valid_address|
+        user.email = valid_address
+        expect(user).to be_valid
+      end
+    end
+
+    it 'email validation should reject invalid addresses' do
+      user = build(:user)
+      invalid_addresses = %w(user@example,com user_at_foo.org user.name@example.
+                           foo@bar_baz.com foo@bar+baz.com)
+      invalid_addresses.each do |invalid_address|
+        user.email = invalid_address
+        expect(user).to_not be_valid
+      end
+    end
+
+    it 'email addresses should be unique' do
+      user = create(:user)
+      duplicate_user = user.dup
+      expect(duplicate_user).to_not be_valid
+    end
+  end
+
+  describe '#downcase_email' do
+    it 'email should be lowercase' do
+      user = build(:user, email: 'TEST@EXAMPLE.COM')
+      expect(user.send(:downcase_email)).to eq 'test@example.com'
+    end
+
+    it 'should be performed before save' do
+      user = build(:user, email: 'TEST@EXAMPLE.COM')
+      user.save!
+      expect(user.reload.email).to eq 'test@example.com'
+    end
+  end
+end


### PR DESCRIPTION
### やったこと
- Userモデルのバリデーションを追加
- usersテーブルの`email`と`password_digest`カラムにNOT NULL制約を追加
- models/user_spec.rbの作成
  - テストケースはRailsチュートリアルを参考にした